### PR TITLE
Close connection after every request in test_https_cert_error.

### DIFF
--- a/tests/http_tests.py
+++ b/tests/http_tests.py
@@ -131,6 +131,7 @@ class HttpsCertificateTestCase(TestCase):
         self.assertRaises(pywikibot.FatalServerError,
                           http.fetch,
                           uri='https://testssl-expire-r2i2.disig.sk/index.en.html')
+        http.session.close()  # clear the connection
 
         with warnings.catch_warnings(record=True) as warning_log:
             response = http.fetch(
@@ -139,12 +140,13 @@ class HttpsCertificateTestCase(TestCase):
         r = response.content
         self.assertIsInstance(r, unicode)
         self.assertTrue(re.search(r'<title>.*</title>', r))
+        http.session.close()  # clear the connection
 
         # Verify that it now fails again
-        http.session.close()  # but first clear the connection
         self.assertRaises(pywikibot.FatalServerError,
                           http.fetch,
                           uri='https://testssl-expire-r2i2.disig.sk/index.en.html')
+        http.session.close()  # clear the connection
 
         # Verify that the warning occurred
         self.assertEqual(len(warning_log), 1)


### PR DESCRIPTION
Hanging connection create unexpected warning during another request to the
same host.

Bug: T151248
Change-Id: I5c2d2b4461eba04df3f4b41a0862b574d404af82