### PR TITLE
add option to detect edited section automagically

### DIFF
--- a/pywikibot/config2.py
+++ b/pywikibot/config2.py
@@ -773,6 +773,13 @@ cosmetic_changes_disable = {}
 cosmetic_changes_deny_script = ['category_redirect', 'cosmetic_changes',
                                 'newitem', 'touch']
 
+# ############# MODIFIED SECTION SETTINGS ################
+# The bot can automatically detect the edited section (if a single one),
+# and notice it in the edit summary.
+
+# This is an experimental feature; handle with care!
+modified_section = False
+
 # ############# REPLICATION BOT ################
 # You can add replicate_replace to your user_config.py, which has the following
 # format:

--- a/tests/textlib_tests.py
+++ b/tests/textlib_tests.py
@@ -96,6 +96,169 @@ class TestSectionFunctions(TestCase):
                                'section header must contain a link')
 
 
+class TestModifiedSectionDetection(TestCase):
+
+    """Test modified_sections()."""
+
+    net = False
+
+    def testSimpleChange(self):
+        oldText = """
+=== Section 1 ===
+Some text
+
+=== Section 2 ===
+Some other text"""
+
+        newText = """
+=== Section 1 ===
+Some modified text
+
+=== Section 2 ===
+Some other text"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         [u'Section 1'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_level=True),
+                         [u'Section 1'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_spacing=True),
+                         [u'Section 1'])
+
+    def testMultipleChange(self):
+        oldText = """
+=== Section 1 ===
+Some text
+
+=== Section 2 ===
+Some other text
+
+=== Section 3 ===
+Something"""
+
+        newText = """
+=== Section 1 ===
+Some modified text
+
+=== Section 2 ===
+Some other text, also modified
+
+=== Section 3 ===
+Something"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         [u'Section 1', u'Section 2'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_level=True),
+                         [u'Section 1', u'Section 2'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_spacing=True),
+                         [u'Section 1', u'Section 2'])
+
+    def testChangedLevel(self):
+        oldText = """
+=== Section 1 ===
+Some text
+
+=== Section 2 ===
+Some other text"""
+
+        newText = """
+=== Section 1 ===
+Some text
+
+==== Section 2 ====
+Some other text"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         [])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_level=True),
+                         [u'Section 2'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_spacing=True),
+                         [])
+
+    def testChangeSpacing(self):
+        oldText = """
+=== Section 1 ===
+Some text
+
+=== Section 2 ===
+Some other text"""
+
+        newText = """
+=== Section 1 ===
+Some text
+
+===  Section 2  ===
+Some other text"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         [])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_level=True),
+                         [])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_spacing=True),
+                         [u'Section 2'])
+
+    def testDuplicateSections(self):
+        oldText = """
+=== Section ===
+Some text
+
+=== Section ===
+Some other text"""
+
+        newText = """
+=== Section ===
+Some text
+
+=== Section ===
+Some modified text"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         None)
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_level=True),
+                         None)
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, changed_spacing=True),
+                         None)
+
+    def testUnprintableSection(self):
+        oldText = """
+=== Section 1 ===
+Some text
+
+=== Section [[2]] ===
+Some other text"""
+
+        newText = """
+=== Section 1 ===
+Some text
+
+=== Section [[2]] ===
+Some other text!"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         None)
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, raw_only=False),
+                         [u'Section [[2]]'])
+
+    def testUnprintableSectionNotEdited(self):
+        oldText = """
+=== Section [[1]] ===
+Some text
+
+=== Section 2 ===
+Some other text"""
+
+        newText = """
+=== Section [[1]] ===
+Some text
+
+=== Section 2 ===
+Some other text!"""
+
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText),
+                         [u'Section 2'])
+        self.assertEqual(pywikibot.textlib.modified_sections(oldText, newText, raw_only=False),
+                         [u'Section 2'])
+
+
 class TestFormatInterwiki(TestCase):
 
     """Test format functions."""


### PR DESCRIPTION
new functions:
    textlib.split_into_sections (powered by mwparserfromhell)
    textlib.modified_sections
new hook:
    Page._modified_section_hook
new configuration key:
    modified_section

as well as tests to check textlib.modified_sections

Bug: T67989

Change-Id: I7a157afaf985902d1c19d2d92f3c314e0d2f6ecd